### PR TITLE
add parametized url for load_and_verify

### DIFF
--- a/lib/site_prism_plus/page.rb
+++ b/lib/site_prism_plus/page.rb
@@ -15,8 +15,19 @@ module SitePrismPlus
     end
 
     # Page loads typically takes longer.
-    def load_and_verify(element_name)
-      load_override(element_name)
+    def load_and_verify(verify_element, url_hash = nil)
+      result = true
+      @metrics.start_time
+      if url_hash.nil?
+        load
+      else
+        load(url_hash)
+      end
+      if verify_element
+        result = wait_till_element_visible(verify_element, 3)
+      end
+      @metrics.log_metric(@page_name, 'load', verify_element)
+      result
     end
 
     def log_transition_metric(click_element, verify_element)
@@ -32,19 +43,6 @@ module SitePrismPlus
 
     def metrics_file
       @metrics.default_log_file
-    end
-
-    private
-
-    def load_override(verify_element = nil)
-      result = true
-      @metrics.start_time
-      load
-      if verify_element
-        result = wait_till_element_visible(verify_element, 3)
-      end
-      @metrics.log_metric(@page_name, 'load', verify_element)
-      result
     end
 
   end

--- a/lib/site_prism_plus/version.rb
+++ b/lib/site_prism_plus/version.rb
@@ -1,3 +1,3 @@
 module SitePrismPlus
-  VERSION = "0.4.0"
+  VERSION = "0.5.0"
 end

--- a/spec/page_load_url_spec.rb
+++ b/spec/page_load_url_spec.rb
@@ -1,0 +1,39 @@
+require_relative 'spec_helper'
+
+# NOTES:
+# - phptravels.com is a good site to test since it has timing variations.
+# - This site's popup notification - after clicking cancel to close the popup, immediate execution
+#   of a capybara find will still find the popup. Instances like this dictates adding a needed
+#   sleep between closing the popup and checking if the popup is still open
+# - Site also contains duplicate locators - caught with Ambiguous match, found 2 elements
+describe "Extended Plus Page" do
+  include CapybaraHelper
+
+  class DemoSite < SitePrismPlus::Page
+    element :logo, :xpath, '//img[@src="//phptravels.com/assets/img/logo.png"]'
+    element :popup_cancel, '#onesignal-popover-cancel-button'
+    element :popup_img, :xpath, '//img[@src="https://img.onesignal.com/t/e998c836-a08e-443d-8a04-ae42122635e1.png"]'
+    element :popup_box, '#onesignal-popover-dialog'
+    element :popup_allow, '#onesignal-popover-allow-button'
+    element :product_menu, :xpath, '//span[contains(text(), "Product")]'
+    element :documentation, :xpath, '//a[@href="//phptravels.com/documentation/"]'
+    element :doc_header, :xpath, '//h2[contains(text(), "Documentation")]'
+    element :non_exist, '#doesnotexist'
+    element :feature_page_header, :xpath, '//h2[contains(text(), "Web App Features")]'
+    set_url "https://phptravels.com{/header}"
+  end
+
+  let(:demo_site) { DemoSite.new('demo_homepage') }
+  let(:documentation) { Documentation.new('documentation_page') }
+
+  it 'should load demo site homepage with method load_and_verify without parametized URL' do
+    result = demo_site.load_and_verify('logo')
+    expect(result).to equal true
+  end
+
+  it 'should load with method load_and_verify with parametized URL' do
+    result = demo_site.load_and_verify('feature_page_header', header: 'features')
+    expect(result).to equal true
+  end
+
+end


### PR DESCRIPTION
**Before**
 - loan_and_verify method does not support the parametized URL hash
**After**
 - Paramterized url hash values can be passed as a second parameter
  Ex

  page.load_and_verify('element_name', url_param: 'username')