### PR TITLE
remove required name page when initialized

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    site_prism_plus (0.6.0)
+    site_prism_plus (0.6.1)
       site_prism (~> 2.8)
 
 GEM

--- a/lib/site_prism_plus/page.rb
+++ b/lib/site_prism_plus/page.rb
@@ -9,8 +9,14 @@ module SitePrismPlus
   class Page < SitePrism::Page
     include SitePrismPlusCommons
 
-    def initialize(page_name)
-      @page_name = page_name
+    attr_accessor :page_name
+
+    def initialize(pname = nil)
+      if pname
+        @page_name = pname
+      else
+        @page_name = self.class.to_s
+      end
       @metrics = Metrics.instance
     end
 

--- a/lib/site_prism_plus/version.rb
+++ b/lib/site_prism_plus/version.rb
@@ -1,3 +1,3 @@
 module SitePrismPlus
-  VERSION = "0.6.0"
+  VERSION = "0.6.1"
 end

--- a/spec/page_spec.rb
+++ b/spec/page_spec.rb
@@ -22,6 +22,10 @@ describe "Extended Plus Page" do
     set_url "https://phptravels.com/demo/"
   end
 
+  class NameTestPage < SitePrismPlus::Page
+    set_url "https:google.com"
+  end
+
   class Documentation < SitePrismPlus::Page
     element :doc_search, :id, 'docsQuery'
     element :payment_gateway, :xpath, '//div[contains(text(), "Payment Gateways")]'
@@ -31,6 +35,15 @@ describe "Extended Plus Page" do
 
   let(:demo_site) { DemoSite.new('demo_homepage') }
   let(:documentation) { Documentation.new('documentation_page') }
+  let(:name_test_page) { NameTestPage.new }
+
+  it 'should set page_name to class name if not defined' do
+    expect(name_test_page.page_name).to eql("NameTestPage")
+  end
+
+  it 'should set page_name to passed string' do
+    expect(demo_site.page_name).to eql("demo_homepage")
+  end
 
   it 'should have a url value' do
     demo_site.reset_logfile


### PR DESCRIPTION
**Before**
* Initialize requires a page name

**After**
* Initialize does not need page name
* default page name is the name of the class