### PR TITLE
change min site_prism to 2018 vesrion

### DIFF
--- a/lib/site_prism_plus/version.rb
+++ b/lib/site_prism_plus/version.rb
@@ -1,3 +1,3 @@
 module SitePrismPlus
-  VERSION = "0.6.1"
+  VERSION = "0.6.2"
 end

--- a/site_prism_plus.gemspec
+++ b/site_prism_plus.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
   spec.bindir        = "exe"
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
-  spec.add_dependency "site_prism", "~> 2.8"
+  spec.add_dependency "site_prism", "~> 2.10"
 
   # NOTE: breaking with pry seems to affect webdriver that it could
   #       not find the elements in the current window


### PR DESCRIPTION
Min site_prism version required changed to 2018 version