### PR TITLE
updated site_prism to latest, fix spec for deprecated

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,8 @@
 PATH
   remote: .
   specs:
-    site_prism_plus (0.6.1)
-      site_prism (~> 2.8)
+    site_prism_plus (0.6.3)
+      site_prism (~> 2.17.1)
 
 GEM
   remote: https://rubygems.org/
@@ -11,13 +11,13 @@ GEM
       public_suffix (>= 2.0.2, < 4.0)
     archive-zip (0.11.0)
       io-like (~> 0.3.0)
-    capybara (2.18.0)
+    capybara (3.5.1)
       addressable
       mini_mime (>= 0.1.3)
-      nokogiri (>= 1.3.3)
-      rack (>= 1.0.0)
-      rack-test (>= 0.5.4)
-      xpath (>= 2.0, < 4.0)
+      nokogiri (~> 1.8)
+      rack (>= 1.6.0)
+      rack-test (>= 0.6.3)
+      xpath (~> 3.1)
     childprocess (0.9.0)
       ffi (~> 1.0, >= 1.0.11)
     chromedriver-helper (1.2.0)
@@ -28,16 +28,16 @@ GEM
     ffi (1.9.25)
     io-like (0.3.0)
     method_source (0.9.0)
-    mini_mime (1.0.0)
+    mini_mime (1.0.1)
     mini_portile2 (2.3.0)
     nokogiri (1.8.2)
       mini_portile2 (~> 2.3.0)
     pry (0.11.3)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
-    public_suffix (3.0.2)
+    public_suffix (3.0.3)
     rack (2.0.5)
-    rack-test (1.0.0)
+    rack-test (1.1.0)
       rack (>= 1.0, < 3)
     rake (10.5.0)
     rspec (3.7.0)
@@ -57,9 +57,9 @@ GEM
     selenium-webdriver (3.10.0)
       childprocess (~> 0.5)
       rubyzip (~> 1.2)
-    site_prism (2.14)
+    site_prism (2.17.1)
       addressable (~> 2.4)
-      capybara (~> 2.12)
+      capybara (>= 2.15, < 3.6)
     xpath (3.1.0)
       nokogiri (~> 1.8)
 

--- a/lib/site_prism_plus/version.rb
+++ b/lib/site_prism_plus/version.rb
@@ -1,3 +1,3 @@
 module SitePrismPlus
-  VERSION = "0.6.2"
+  VERSION = "0.6.3"
 end

--- a/site_prism_plus.gemspec
+++ b/site_prism_plus.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
   spec.bindir        = "exe"
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
-  spec.add_dependency "site_prism", "~> 2.10"
+  spec.add_dependency "site_prism", "~> 2.17.1"
 
   # NOTE: breaking with pry seems to affect webdriver that it could
   #       not find the elements in the current window

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -24,7 +24,7 @@ module CapybaraHelper
   end
 
   Capybara.javascript_driver = :chrome
-  Capybara.wait_on_first_by_default = true
+  #Capybara.wait_on_first_by_default = true
   Capybara.configure do |config|
     config.default_max_wait_time = 5 # seconds
     config.default_driver        = :chrome


### PR DESCRIPTION
## Before
- 2.10 site_prism version (bug with iframe)

## After
- latest 2.14 version with fix
- removed Capybara.wait_on_first_by_default = true, not supported anymore