### PR TITLE
new parameter for send_text

### DIFF
--- a/lib/site_prism_plus/site_prism_plus_commons.rb
+++ b/lib/site_prism_plus/site_prism_plus_commons.rb
@@ -245,12 +245,13 @@ module SitePrismPlusCommons
   # - happens with input fields not ready
   # - pre-populated values
   # - character send does not register especially with auto-complete fields
-  def send_text(element_name, txt_to_send)
+  def send_text(element_name, txt_to_send, expected_text = nil)
     nretry = 0
+    expected_text ||= txt_to_send
     while nretry < 2
       nretry += 1
       if send_keys(element_name, txt_to_send)
-        if wait_for_text(element_name, txt_to_send)
+        if wait_for_text(element_name, expected_text)
           return true
         end
       end


### PR DESCRIPTION
**Before**
- send_text method compares sent text with itself
**After**
- send_text method has optional parameter to check the sent text with the optional text
- Used when entered text is formatted by the input field
- if optional parameter is omitted, behavior is same as before
Ex:
  sent text is "100"
  displayed value is "$100"

Then page_obj.send_text('elem_name', '100', '$100')