### PR TITLE
Modify click element expected element

### DIFF
--- a/lib/site_prism_plus/site_prism_plus_commons.rb
+++ b/lib/site_prism_plus/site_prism_plus_commons.rb
@@ -143,12 +143,12 @@ module SitePrismPlusCommons
   # * *Args*    :
   #   - +element_name+ -> name of element defined
   #   - +expected_element_name+ -> name of element to verify after the click
-  #   - +expected_type+ -> locator type of element to verify
-  #   - +expected_locator+ -> syntax for element to verify
+  #   - +till_visible+ -> boolean, if true will wait till expected_element_name is visible
+  #                     if false, will wait till expected_element_name is no longer visible
   # * *Returns* :
   #   - true if after clicking an element the expected element is found
   #     false otherwise
-  def click_element(element_name, expected_element_name = nil)
+  def click_element(element_name, expected_element_name = nil, till_visible = true)
     result = false
     nretry = 0
     while !result && nretry < 2
@@ -158,8 +158,16 @@ module SitePrismPlusCommons
         result = click_action(elem_to_click, element_name)
         dbg_msg('info',"Clicking element - #{element_name}")
         if expected_element_name
-          result = is_element_visible?(expected_element_name)
-          dbg_msg('info', "Expected element after click: #{expected_element_name} visible? - #{result}")
+          result = true
+          visibility = is_element_visible?(expected_element_name)
+          if till_visible && !visibility
+            result = false
+            dbg_msg('error', "Expected element after click: #{expected_element_name} visible? - #{result}")
+          end
+          if !till_visible && visibility
+            result = false
+            dbg_msg('error', "Element still visible after click: #{expected_element_name} visible? - #{result}")
+          end
         end
       end
       if !result && nretry < 2

--- a/lib/site_prism_plus/version.rb
+++ b/lib/site_prism_plus/version.rb
@@ -1,3 +1,3 @@
 module SitePrismPlus
-  VERSION = "0.6.7"
+  VERSION = "0.6.8"
 end


### PR DESCRIPTION
**Before**
- click_element can only have option for resulting element to be visible
**After**
- click element can check for resulting element to either be visible or not visible anymore

Ex: click_element('xpath_elem', 'xpath_expected', false)
    => This would verify that element xpath_expected is NOT visible anymore